### PR TITLE
Use Lock per auto merge queue correctly

### DIFF
--- a/command_accept_changeset.go
+++ b/command_accept_changeset.go
@@ -18,7 +18,7 @@ type AcceptCommand struct {
 	cmd     AcceptChangesetCommand
 	info    *setting.RepositoryInfo
 
-	queue *queue.AutoMergeQueue
+	autoMergeRepo *queue.AutoMergeQRepo
 }
 
 func (c *AcceptCommand) commandAcceptChangesetByReviewer(ev *github.IssueCommentEvent) (bool, error) {
@@ -77,16 +77,21 @@ func (c *AcceptCommand) commandAcceptChangesetByReviewer(ev *github.IssueComment
 	}
 
 	if c.info.EnableAutoMerge {
-		c.queue.Lock()
-		defer c.queue.Unlock()
+		c.autoMergeRepo.Lock()
+		defer c.autoMergeRepo.Unlock()
 
-		q := &queue.AutoMergeQueueItem{
+		q := c.autoMergeRepo.Get(repoOwner, repoName)
+
+		q.Lock()
+		defer q.Unlock()
+
+		item := &queue.AutoMergeQueueItem{
 			PullRequest: issue,
 			SHA:         nil,
 		}
-		c.queue.Push(q)
+		q.Push(item)
 
-		if c.queue.HasActive() {
+		if q.HasActive() {
 			log.Printf("info: pull request (%v) has been queued but other is active.\n", issue)
 			{
 				comment := ":postbox: This pull request is queued. Please await the time."
@@ -97,13 +102,13 @@ func (c *AcceptCommand) commandAcceptChangesetByReviewer(ev *github.IssueComment
 			return true, nil
 		}
 
-		ok, next := c.queue.GetNext()
+		ok, next := q.GetNext()
 		if !ok || next == nil {
 			log.Println("error: this queue should not be empty because `q` is queued just now.")
 			return false, nil
 		}
 
-		if next != q {
+		if next != item {
 			log.Println("error: `next` should be equal to `q` because there should be only `q` in queue.")
 			return false, nil
 		}
@@ -114,10 +119,10 @@ func (c *AcceptCommand) commandAcceptChangesetByReviewer(ev *github.IssueComment
 			return false, nil
 		}
 
-		q.SHA = commit.SHA
-		c.queue.SetActive(q)
+		item.SHA = commit.SHA
+		q.SetActive(item)
 		log.Printf("info: pin #%v as the active item to queue\n", issue)
-		c.queue.Save()
+		q.Save()
 	}
 
 	log.Printf("info: complete merge the pull request %v\n", issue)

--- a/command_accept_changeset.go
+++ b/command_accept_changeset.go
@@ -77,13 +77,11 @@ func (c *AcceptCommand) commandAcceptChangesetByReviewer(ev *github.IssueComment
 	}
 
 	if c.info.EnableAutoMerge {
-		c.autoMergeRepo.Lock()
-		defer c.autoMergeRepo.Unlock()
+		qHandle := c.autoMergeRepo.Get(repoOwner, repoName)
+		qHandle.Lock()
+		defer qHandle.Unlock()
 
-		q := c.autoMergeRepo.Get(repoOwner, repoName)
-
-		q.Lock()
-		defer q.Unlock()
+		q := qHandle.Load()
 
 		item := &queue.AutoMergeQueueItem{
 			PullRequest: issue,

--- a/command_check_autobranch.go
+++ b/command_check_autobranch.go
@@ -37,12 +37,12 @@ func (srv *AppServer) checkAutoBranch(ev *github.StatusEvent) {
 	}
 	log.Println("info: Start to handle auto merging the branch.")
 
-	srv.autoMergeRepo.Lock()
-	q := srv.autoMergeRepo.Get(repoOwner, repoName)
-	defer srv.autoMergeRepo.Unlock()
+	qHandle := srv.autoMergeRepo.Get(repoOwner, repoName)
 
-	q.Lock()
-	defer q.Unlock()
+	qHandle.Lock()
+	defer qHandle.Unlock()
+
+	q := qHandle.Load()
 
 	if !q.HasActive() {
 		log.Println("info: there is no testing item")

--- a/command_check_autobranch.go
+++ b/command_check_autobranch.go
@@ -39,7 +39,7 @@ func (srv *AppServer) checkAutoBranch(ev *github.StatusEvent) {
 
 	srv.autoMergeRepo.Lock()
 	q := srv.autoMergeRepo.Get(repoOwner, repoName)
-	srv.autoMergeRepo.Unlock()
+	defer srv.autoMergeRepo.Unlock()
 
 	q.Lock()
 	defer q.Unlock()

--- a/server.go
+++ b/server.go
@@ -100,13 +100,6 @@ func (srv *AppServer) processIssueCommentEvent(ev *github.IssueCommentEvent) (bo
 		return false, fmt.Errorf("debug: cannot get repositoryInfo")
 	}
 
-	var queue *queue.AutoMergeQueue
-	if repoInfo.EnableAutoMerge {
-		srv.autoMergeRepo.Lock()
-		queue = srv.autoMergeRepo.Get(repoOwner, repo)
-		srv.autoMergeRepo.Unlock()
-	}
-
 	switch cmd := cmd.(type) {
 	case *AssignReviewerCommand:
 		return srv.commandAssignReviewer(ev, cmd.Reviewer)
@@ -118,7 +111,7 @@ func (srv *AppServer) processIssueCommentEvent(ev *github.IssueCommentEvent) (bo
 			config.BotNameForGithub(),
 			cmd,
 			repoInfo,
-			queue,
+			srv.autoMergeRepo,
 		}
 		return commander.commandAcceptChangesetByReviewer(ev)
 	case *AcceptChangeByOthersCommand:
@@ -129,7 +122,7 @@ func (srv *AppServer) processIssueCommentEvent(ev *github.IssueCommentEvent) (bo
 			config.BotNameForGithub(),
 			cmd,
 			repoInfo,
-			queue,
+			srv.autoMergeRepo,
 		}
 		return commander.commandAcceptChangesetByOtherReviewer(ev, cmd.Reviewer[0])
 	default:


### PR DESCRIPTION
In the previous code, `AutoMergeQueue.mux` is created every time on created `AutoMergeQueue`. But `AutoMergeQueue` is always created on loading local stored json queue. So there are no guarantee to work a mutex correctly.

By this change, AutoMergeQRepo is giant-locked to fix the above problem.

## Related Issues

- Depend on https://github.com/karen-irc/popuko/pull/130