### PR TITLE
Check the commit hash before to start trying to merge into upstream.

### DIFF
--- a/command_accept_changeset.go
+++ b/command_accept_changeset.go
@@ -85,7 +85,7 @@ func (c *AcceptCommand) commandAcceptChangesetByReviewer(ev *github.IssueComment
 
 		item := &queue.AutoMergeQueueItem{
 			PullRequest: issue,
-			SHA:         nil,
+			SHA:         &headSha,
 		}
 		q.Push(item)
 		q.Save()


### PR DESCRIPTION
This prevents the attack that pushing the malicious commit after the pull request is accepted.

Fix https://github.com/karen-irc/popuko/issues/105