### PR TITLE
Implement 'r-' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ You can use these command as the comment for pull request.
 - `@<botname> r+`
     - Merge this pull request by `<botname>` with labeling `S-awaiting-merge`.
     - `@<botname> r=<reviewer>` means the same thing.
+- `@<botname> r-`
+    - Cancel the approved by `@<botname> r+`.
+    - This set back the label to `S-awaiting-review`
 - `@<reviewer> r?`
     - Assign the pull request to the reviewer with labeling `S-awaiting-review`.
 

--- a/epic/cancel_approved_changeset.go
+++ b/epic/cancel_approved_changeset.go
@@ -1,0 +1,79 @@
+package epic
+
+import (
+	"log"
+
+	"github.com/google/go-github/github"
+
+	"github.com/karen-irc/popuko/input"
+	"github.com/karen-irc/popuko/operation"
+	"github.com/karen-irc/popuko/queue"
+	"github.com/karen-irc/popuko/setting"
+)
+
+type CancelApprovedCommand struct {
+	BotName       string
+	Client        *github.Client
+	Owner         string
+	Name          string
+	Number        int
+	Cmd           *input.CancelApprovedByReviewerCommand
+	Info          *setting.RepositoryInfo
+	AutoMergeRepo *queue.AutoMergeQRepo
+}
+
+func (c *CancelApprovedCommand) CancelApprovedChangeSet(ev *github.IssueCommentEvent) (ok bool, err error) {
+	id := *ev.Comment.ID
+	log.Printf("info: Start: merge the pull request by %v\n", id)
+	defer log.Printf("info: End: merge the pull request by %v\n", id)
+
+	if c.BotName != c.Cmd.BotName() {
+		log.Printf("info: this command works only if target user is actual our bot.")
+		return false, nil
+	}
+
+	sender := *ev.Sender.Login
+	log.Printf("debug: command is sent from %v\n", sender)
+
+	if !c.Info.IsReviewer(sender) {
+		log.Printf("info: %v is not an reviewer registred to this bot.\n", sender)
+		return false, nil
+	}
+
+	owner := c.Owner
+	name := c.Name
+	number := c.Number
+	log.Printf("debug: issue number is %v\n", number)
+
+	currentLabels := operation.GetLabelsByIssue(c.Client.Issues, owner, name, number)
+	if currentLabels != nil {
+		labels := operation.AddAwaitingReviewLabel(currentLabels)
+
+		// https://github.com/nekoya/popuko/blob/master/web.py
+		_, _, err = c.Client.Issues.ReplaceLabelsForIssue(owner, name, number, labels)
+		if err != nil {
+			log.Printf("info: could not change labels by the issue: %v\n", err)
+		}
+	}
+
+	{
+		comment := ":outbox_tray: This has been cancelled from the approved queue by `" + sender + "`"
+		if ok := operation.AddComment(c.Client.Issues, owner, name, number, comment); !ok {
+			log.Println("info: could not create the comment about what this pull request rejected.")
+		}
+	}
+
+	if c.Info.EnableAutoMerge {
+		qHandle := c.AutoMergeRepo.Get(owner, name)
+		qHandle.Lock()
+		defer qHandle.Unlock()
+
+		q := qHandle.Load()
+		if found := q.RemoveAwaiting(number); found {
+			q.Save()
+		}
+	}
+
+	log.Printf("info: complete to reject the pull request %v\n", number)
+	return true, nil
+}

--- a/input/command.go
+++ b/input/command.go
@@ -55,3 +55,11 @@ func (s *AcceptChangeByOthersCommand) BotName() string {
 type AssignReviewerCommand struct {
 	Reviewer string
 }
+
+type CancelApprovedByReviewerCommand struct {
+	botName string
+}
+
+func (s *CancelApprovedByReviewerCommand) BotName() string {
+	return s.botName
+}

--- a/input/command_test.go
+++ b/input/command_test.go
@@ -157,10 +157,10 @@ func TestParseCommand13(t *testing.T) {
 }
 
 func TestParseCommand14(t *testing.T) {
-	ok, cmd := ParseCommand(`@bot        r+          
-	
+	ok, cmd := ParseCommand(`@bot        r+
 
-	
+
+
 	`)
 	if !ok {
 		t.Fatal("should be ok")
@@ -185,6 +185,18 @@ func TestParseCommand15(t *testing.T) {
 	v, ok := cmd.(*AcceptChangeByReviewerCommand)
 	if !ok {
 		t.Fatal("should be AcceptChangeByReviewerCommand")
+	}
+
+	if name := v.BotName(); name != "bot" {
+		t.Fatalf("should be the expected bot name: %v\n", name)
+	}
+}
+
+func TestParseCommand16(t *testing.T) {
+	ok, cmd := ParseCommand("@bot r-")
+	v, ok := cmd.(*CancelApprovedByReviewerCommand)
+	if !ok {
+		t.Fatal("should be CancelApprovedByReviewerCommand")
 	}
 
 	if name := v.BotName(); name != "bot" {

--- a/input/parser.go
+++ b/input/parser.go
@@ -73,6 +73,14 @@ func (p *parser) parseAskToUser() (interface{}, error) {
 		result = &AcceptChangeByReviewerCommand{
 			botName: person[0],
 		}
+	case tMinus:
+		if len(person) > 1 {
+			return nil, fmt.Errorf("found person is %v, person should be only 1", len(person))
+		}
+
+		result = &CancelApprovedByReviewerCommand{
+			botName: person[0],
+		}
 	case tEqual:
 		reviewer := make([]string, 0, 1)
 		for {

--- a/input/scanner.go
+++ b/input/scanner.go
@@ -30,6 +30,7 @@ const (
 	tQuestion // ?
 	tAtmark   // @
 	tPlus     // +
+	tMinus    // -
 )
 
 type scanner struct {
@@ -67,6 +68,8 @@ func (s *scanner) Scan() (tok token, literal string) {
 		return tAtmark, literal
 	case '+':
 		return tPlus, literal
+	case '-':
+		return tMinus, literal
 	}
 
 	return tIllegal, literal

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -103,6 +103,27 @@ func (s *AutoMergeQueue) GetNext() (ok bool, item *AutoMergeQueueItem) {
 	return true, front
 }
 
+func (s *AutoMergeQueue) RemoveAwaiting(pr int) (found bool) {
+	active := s.GetActive()
+	if (active != nil) && (active.PullRequest == pr) {
+		log.Printf("debug: the current active is %v\n", pr)
+		s.RemoveActive()
+		return true
+	}
+
+	n := make([]*AutoMergeQueueItem, 0, len(s.q)-1) // create small slice with huristic buffer size.
+	for _, item := range s.q {
+		if item.PullRequest == pr {
+			found = true
+		} else {
+			n = append(n, item)
+		}
+	}
+
+	s.q = n
+	return found
+}
+
 func (s *AutoMergeQueue) GetActive() *AutoMergeQueueItem {
 	return s.current
 }

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -1,0 +1,64 @@
+package queue
+
+import (
+	"log"
+	"testing"
+)
+
+// Should remove the active
+func Test_AutoMergeQueue_RemoveAwaiting1(t *testing.T) {
+	const number int = 1
+
+	queue := AutoMergeQueue{}
+	i1 := &AutoMergeQueueItem{
+		PullRequest: number,
+	}
+	queue.SetActive(i1)
+
+	if ok := queue.RemoveAwaiting(number); !ok {
+		t.Fatalf("should be success to remove the awaiting")
+	}
+
+	if queue.HasActive() {
+		t.Fatalf("queue.HasActive() should be false")
+	}
+
+	if queue.GetActive() != nil {
+		t.Fatalf("queue.GetActive() should be nil")
+	}
+}
+
+// Should remove the item in the queue.
+func Test_AutoMergeQueue_RemoveAwaiting2(t *testing.T) {
+	const number int = 1
+
+	queue := AutoMergeQueue{}
+	list := []*AutoMergeQueueItem{
+		&AutoMergeQueueItem{
+			PullRequest: number,
+		},
+		&AutoMergeQueueItem{
+			PullRequest: number + 1,
+		},
+		&AutoMergeQueueItem{
+			PullRequest: number + 2,
+		},
+	}
+	for _, item := range list {
+		queue.Push(item)
+	}
+
+	if ok := queue.RemoveAwaiting(number + 1); !ok {
+		t.Fatalf("should be success to remove the awaiting")
+	}
+
+	ok, next := queue.GetNext()
+	if !ok {
+		t.Fatalf("queue.GetNext() should be ok=true")
+	}
+
+	if next != list[0] {
+		log.Printf("debug: queue is :%+v\n", queue)
+		t.Fatalf("queue.GetNext() should return the front of list, but %v\n", next)
+	}
+}

--- a/server.go
+++ b/server.go
@@ -125,6 +125,18 @@ func (srv *AppServer) processIssueCommentEvent(ev *github.IssueCommentEvent) (bo
 			srv.autoMergeRepo,
 		}
 		return commander.AcceptChangesetByOtherReviewer(ev, cmd.Reviewer[0])
+	case *input.CancelApprovedByReviewerCommand:
+		commander := epic.CancelApprovedCommand{
+			BotName:       config.BotNameForGithub(),
+			Client:        srv.githubClient,
+			Owner:         repoOwner,
+			Name:          repo,
+			Number:        *ev.Issue.Number,
+			Cmd:           cmd,
+			Info:          repoInfo,
+			AutoMergeRepo: srv.autoMergeRepo,
+		}
+		return commander.CancelApprovedChangeSet(ev)
 	default:
 		return false, fmt.Errorf("error: unreachable")
 	}


### PR DESCRIPTION
## Motivation

- This command can stop accepting a pull request which has been approved.
- This is a pair of `@<botname> r+`

## Details

- `@<botname> r-`
-  This command stop accepting a pull request which has been approved if the pull request has been approved & awaiting to merge into the upstream.
 

## Related issues.

- Fix https://github.com/karen-irc/popuko/issues/38

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/popuko/157)
<!-- Reviewable:end -->
