### PR TITLE
Change the sign to not accepted change set to :no_entry_sign: from :no_entry:

### DIFF
--- a/operation/comment.go
+++ b/operation/comment.go
@@ -22,7 +22,7 @@ func AddComment(issueSvc *github.IssuesService, owner string, name string, issue
 func CommentHeadIsDifferentFromAccepted(issueSvc *github.IssuesService, owner string, name string, prNum int) {
 	log.Printf("info: the head of #%v is changed from r+.\n", prNum)
 
-	comment := ":no_entry: The current head is changed from when this had been accepted. Please review again."
+	comment := ":no_entry_sign: The current head is changed from when this had been accepted. Please review again. :no_entry_sign:"
 	if ok := AddComment(issueSvc, owner, name, prNum, comment); !ok {
 		log.Println("error: could not write the comment about the result of auto branch.")
 	}


### PR DESCRIPTION
- This fix the regeression caused by https://github.com/karen-irc/popuko/pull/148
- This retry https://github.com/karen-irc/popuko/pull/151

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/popuko/159)
<!-- Reviewable:end -->
