### PR TITLE
Add the option to reject webhooks from non-expected repositories.

### DIFF
--- a/example.config.toml
+++ b/example.config.toml
@@ -19,3 +19,8 @@ api_token = "api_token"
 
 # GitHub Webhook secret
 webhook_secret = "webhook_secret"
+
+# For security reasons, you can restrict a repository which this bot supports.
+#   - If this list is empty, this bot accepts all webhook incoming from any repositories.
+#   - Otherwise, this bot only accepts the webhook from repositories listed in this item.
+accepted_repositoies = [ "karen-irc/popuko" ]

--- a/main.go
+++ b/main.go
@@ -106,7 +106,11 @@ func main() {
 		return
 	}
 
-	server := AppServer{github, q}
+	server := AppServer{
+		githubClient:  github,
+		autoMergeRepo: q,
+		setting:       config,
+	}
 
 	http.HandleFunc("/github", server.handleGithubHook)
 

--- a/setting/github.go
+++ b/setting/github.go
@@ -1,7 +1,39 @@
 package setting
 
 type GithubSetting struct {
-	BotName    string `toml:"botname"`
-	Token      string `toml:"api_token"`
-	HookSecret string `toml:"webhook_secret"`
+	BotName      string   `toml:"botname"`
+	Token        string   `toml:"api_token"`
+	HookSecret   string   `toml:"webhook_secret"`
+	Repositories []string `toml:"accepted_repositoies"`
+
+	acceptedRepos map[string]bool
+}
+
+func initGithubSetting(g *GithubSetting) {
+	list := g.Repositories
+	g.Repositories = nil
+
+	if (list == nil) || (len(list) == 0) {
+		g.acceptedRepos = nil
+		return
+	}
+
+	m := make(map[string]bool)
+	for _, r := range list {
+		m[r] = true
+	}
+
+	g.acceptedRepos = m
+	return
+}
+
+func (g *GithubSetting) accept(owner, name string) bool {
+	// We regards the empty list as "Accept all incoming webhook".
+	if g.acceptedRepos == nil {
+		return true
+	}
+
+	k := owner + "/" + name
+	_, ok := g.acceptedRepos[k]
+	return ok
 }

--- a/setting/github_test.go
+++ b/setting/github_test.go
@@ -1,0 +1,50 @@
+package setting
+
+import "testing"
+
+const expectedK = "bar"
+const expectedV = "foo"
+
+func TestGithubSettingAccept1(t *testing.T) {
+	s := GithubSetting{
+		Repositories: make([]string, 0),
+	}
+	initGithubSetting(&s)
+
+	if actual := s.accept(expectedK, expectedV); !actual {
+		t.Fatalf("expected: %v\n", actual)
+	}
+}
+
+func TestGithubSettingAccept2(t *testing.T) {
+	s := GithubSetting{
+		Repositories: nil,
+	}
+	initGithubSetting(&s)
+
+	if actual := s.accept(expectedK, expectedV); !actual {
+		t.Fatalf("expected: %v\n", actual)
+	}
+}
+
+func TestGithubSettingAccept3(t *testing.T) {
+	s := GithubSetting{
+		Repositories: []string{expectedK + "/" + expectedV},
+	}
+	initGithubSetting(&s)
+
+	if actual := s.accept(expectedK, expectedV); !actual {
+		t.Fatalf("expected: %v\n", actual)
+	}
+}
+
+func TestGithubSettingAccept4(t *testing.T) {
+	s := GithubSetting{
+		Repositories: []string{"notbar/notfoo"},
+	}
+	initGithubSetting(&s)
+
+	if actual := s.accept(expectedK, expectedV); actual {
+		t.Fatalf("expected: %v\n", actual)
+	}
+}

--- a/setting/settings.go
+++ b/setting/settings.go
@@ -39,6 +39,10 @@ func (s *Settings) WebHookSecret() []byte {
 	return []byte(s.Github.HookSecret)
 }
 
+func (s *Settings) AcceptRepo(owner, name string) bool {
+	return s.Github.accept(owner, name)
+}
+
 const RootConfigFile = "/config.toml"
 
 func LoadSettings(dir string) *Settings {
@@ -48,7 +52,13 @@ func LoadSettings(dir string) *Settings {
 		return nil
 	}
 
-	return decodeFile(path)
+	s := decodeFile(path)
+	if s == nil {
+		return nil
+	}
+
+	initGithubSetting(&s.Github)
+	return s
 }
 
 func decodeFile(path string) *Settings {

--- a/setting/settings_test.go
+++ b/setting/settings_test.go
@@ -26,6 +26,10 @@ func TestLoadConfigToml(t *testing.T) {
 		t.Fatalf("cannot decode the file: %v\n", path)
 	}
 
+	if actual := result.Version; actual != 0 {
+		t.Fatalf("%v\n", actual)
+	}
+
 	if actual := result.BotName; actual != "popuko" {
 		t.Fatalf("%v\n", actual)
 	}
@@ -43,6 +47,10 @@ func TestLoadConfigToml(t *testing.T) {
 	}
 
 	if actual := result.Github.HookSecret; actual != "webhook_secret" {
+		t.Fatalf("%v\n", actual)
+	}
+
+	if actual := result.Github.acceptedRepos; actual != nil {
 		t.Fatalf("%v\n", actual)
 	}
 }


### PR DESCRIPTION
For security reasons, you can restrict a repository which this bot supports.
This introduces `accepted_repositoies` to `config.toml`.
- If this list is empty, this bot accepts all webhook incoming from any repositories.
- Otherwise, this bot only accepts the webhook from repositories listed in this item.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/popuko/183)
<!-- Reviewable:end -->
