### PR TITLE
Support to assign mutiple reviewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ You can use these command as the comment for pull request.
 #### `r? @<reviewer>`
 
 - Assign the reviewer to the pull request with labeling `S-awaiting-review`.
-- You can also call `@<reviewer> r?`.
+- You can call `r? @<reviewer1> @<reviewer2>` to assign multiple reviewers.
+- You can also call `@<reviewer> r?` (But this is deprecated syntax).
 - All user can call this command.
 
 #### `@<botname> r+` or `@<botname> r=<reviewer>`

--- a/epic/assign_reviewer.go
+++ b/epic/assign_reviewer.go
@@ -7,7 +7,7 @@ import (
 	"github.com/karen-irc/popuko/operation"
 )
 
-func AssignReviewer(client *github.Client, ev *github.IssueCommentEvent, target string) (bool, error) {
+func AssignReviewer(client *github.Client, ev *github.IssueCommentEvent, assignees []string) (bool, error) {
 	log.Printf("info: Start: assign the reviewer by %v\n", *ev.Comment.ID)
 	defer log.Printf("info: End: assign the reviewer by %v\n", *ev.Comment.ID)
 
@@ -25,7 +25,6 @@ func AssignReviewer(client *github.Client, ev *github.IssueCommentEvent, target 
 		return false, nil
 	}
 
-	assignees := []string{target}
 	log.Printf("debug: assignees is %v\n", assignees)
 
 	_, _, err := issueSvc.AddAssignees(repoOwner, repo, issue, assignees)

--- a/input/command.go
+++ b/input/command.go
@@ -53,7 +53,7 @@ func (s *AcceptChangeByOthersCommand) BotName() string {
 }
 
 type AssignReviewerCommand struct {
-	Reviewer string
+	Reviewer []string
 }
 
 type CancelApprovedByReviewerCommand struct {

--- a/input/command_test.go
+++ b/input/command_test.go
@@ -199,6 +199,23 @@ func TestParseCommandValidCaseForAssignReviewerCommand(t *testing.T) {
 			input:    "    @reviewer-a   r?",
 			expected: []string{"reviewer-a"},
 		},
+
+		TestCase{
+			input:    "r? @reviewer @reviewer2",
+			expected: []string{"reviewer", "reviewer2"},
+		},
+		TestCase{
+			input:    "r? @reviewer-a @reviewer-b",
+			expected: []string{"reviewer-a", "reviewer-b"},
+		},
+		TestCase{
+			input:    "  r? @reviewer  @reviewer2",
+			expected: []string{"reviewer", "reviewer2"},
+		},
+		TestCase{
+			input:    "   r? @reviewer-a   @reviewer-b",
+			expected: []string{"reviewer-a", "reviewer-b"},
+		},
 	}
 	for _, testcase := range list {
 		input := testcase.input
@@ -215,10 +232,16 @@ func TestParseCommandValidCaseForAssignReviewerCommand(t *testing.T) {
 			continue
 		}
 
-		expected := testcase.expected[0]
-		if actual := v.Reviewer; actual != expected {
-			t.Errorf("input: `%v` should be the expected (`%v`) but `%v`", input, expected, actual)
+		if len(v.Reviewer) != len(testcase.expected) {
+			t.Errorf("input: `%v` should be the expected length (`%v`) but the acutual length is `%v`", input, len(testcase.expected), len(v.Reviewer))
 			continue
+		}
+
+		for i, expected := range testcase.expected {
+			if actual := v.Reviewer[i]; actual != expected {
+				t.Errorf("input: `%v` should be the expected (`%v`) but `%v`", input, expected, actual)
+				continue
+			}
 		}
 	}
 }


### PR DESCRIPTION
We don't support `@<reviewer1> @<reviewer2> r?` syntax because I'd like to make `@<reviewer> r?` be deprecated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/popuko/205)
<!-- Reviewable:end -->
