### PR TITLE
Comment an actual reviewer by 'r=reviewer'

### DIFF
--- a/epic/accept_changeset.go
+++ b/epic/accept_changeset.go
@@ -2,10 +2,13 @@ package epic
 
 import (
 	"log"
+	"strings"
 
 	"github.com/google/go-github/github"
 
 	"errors"
+
+	"fmt"
 
 	"github.com/karen-irc/popuko/input"
 	"github.com/karen-irc/popuko/operation"
@@ -72,12 +75,9 @@ func (c *AcceptCommand) AcceptChangesetByReviewer(ev *github.IssueCommentEvent) 
 	}
 
 	headSha := *pr.Head.SHA
-	{
-		comment := ":pushpin: Commit " + headSha + " has been approved by `" + sender + "`"
-		if ok := operation.AddComment(issueSvc, repoOwner, repoName, issue, comment); !ok {
-			log.Println("info: could not create the comment to declare the head is approved.")
-			return false, nil
-		}
+	if ok := commentApprovedSha(c.Cmd, issueSvc, repoOwner, repoName, issue, headSha, sender); !ok {
+		log.Println("info: could not create the comment to declare the head is approved.")
+		return false, err
 	}
 
 	if c.Info.EnableAutoMerge {
@@ -116,17 +116,51 @@ func (c *AcceptCommand) AcceptChangesetByReviewer(ev *github.IssueCommentEvent) 
 	return true, nil
 }
 
-func (c *AcceptCommand) AcceptChangesetByOtherReviewer(ev *github.IssueCommentEvent, reviewer string) (bool, error) {
+func (c *AcceptCommand) AcceptChangesetByOtherReviewer(ev *github.IssueCommentEvent, reviewer []string) (bool, error) {
 	log.Printf("info: Start: merge the pull request from other reviewer by %v\n", ev.Comment.ID)
 	defer log.Printf("info: End:merge the pull request from other reviewer by %v\n", ev.Comment.ID)
 
-	if !c.Info.IsReviewer(reviewer) {
+	if !c.Info.HasReviewer(reviewer) {
 		log.Println("info: could not find the actual reviewer in reviewer list")
 		log.Printf("debug: specified actial reviewer %v\n", reviewer)
 		return false, nil
 	}
 
 	return c.AcceptChangesetByReviewer(ev)
+}
+
+func commentApprovedSha(cmd input.AcceptChangesetCommand,
+	issues *github.IssuesService,
+	owner,
+	name string,
+	number int,
+	sha string,
+	sender string) bool {
+
+	var reviewers string
+	switch cmd := cmd.(type) {
+	case *input.AcceptChangeByOthersCommand:
+		{
+			list := make([]string, 0, len(cmd.Reviewer))
+			for _, name := range cmd.Reviewer {
+				list = append(list, fmt.Sprintf("`%v`", name))
+			}
+			reviewers = strings.Join(list, ", ")
+		}
+	case *input.AcceptChangeByReviewerCommand:
+		reviewers = fmt.Sprintf("`%v`", sender)
+	default:
+		log.Printf("error: %+v is not handled.", cmd)
+		return false
+	}
+
+	comment := fmt.Sprintf(":pushpin: Commit %v has been approved by %v", sha, reviewers)
+	if ok := operation.AddComment(issues, owner, name, number, comment); !ok {
+		log.Println("info: could not create the comment to declare the head is approved.")
+		return false
+	}
+
+	return true
 }
 
 func queuePullReq(queue *queue.AutoMergeQueue, item *queue.AutoMergeQueueItem) (ok bool, mutated bool) {

--- a/epic/accept_changeset.go
+++ b/epic/accept_changeset.go
@@ -116,19 +116,6 @@ func (c *AcceptCommand) AcceptChangesetByReviewer(ev *github.IssueCommentEvent) 
 	return true, nil
 }
 
-func (c *AcceptCommand) AcceptChangesetByOtherReviewer(ev *github.IssueCommentEvent, reviewer []string) (bool, error) {
-	log.Printf("info: Start: merge the pull request from other reviewer by %v\n", ev.Comment.ID)
-	defer log.Printf("info: End:merge the pull request from other reviewer by %v\n", ev.Comment.ID)
-
-	if !c.Info.HasReviewer(reviewer) {
-		log.Println("info: could not find the actual reviewer in reviewer list")
-		log.Printf("debug: specified actial reviewer %v\n", reviewer)
-		return false, nil
-	}
-
-	return c.AcceptChangesetByReviewer(ev)
-}
-
 func commentApprovedSha(cmd input.AcceptChangesetCommand,
 	issues *github.IssuesService,
 	owner,

--- a/input/command_test.go
+++ b/input/command_test.go
@@ -334,6 +334,7 @@ func TestParseCommandInvalidCase(t *testing.T) {
     r-`,
 
 		// r=reviewer
+		"@bot r=",
 		"@bot r =a",
 		"@bot r = a",
 		"@bot r r=a",

--- a/server.go
+++ b/server.go
@@ -128,7 +128,7 @@ func (srv *AppServer) processIssueCommentEvent(ev *github.IssueCommentEvent) (bo
 			repoInfo,
 			srv.autoMergeRepo,
 		}
-		return commander.AcceptChangesetByOtherReviewer(ev, cmd.Reviewer)
+		return commander.AcceptChangesetByReviewer(ev)
 	case *input.CancelApprovedByReviewerCommand:
 		commander := epic.CancelApprovedCommand{
 			BotName:       config.BotNameForGithub(),

--- a/server.go
+++ b/server.go
@@ -128,7 +128,7 @@ func (srv *AppServer) processIssueCommentEvent(ev *github.IssueCommentEvent) (bo
 			repoInfo,
 			srv.autoMergeRepo,
 		}
-		return commander.AcceptChangesetByOtherReviewer(ev, cmd.Reviewer[0])
+		return commander.AcceptChangesetByOtherReviewer(ev, cmd.Reviewer)
 	case *input.CancelApprovedByReviewerCommand:
 		commander := epic.CancelApprovedCommand{
 			BotName:       config.BotNameForGithub(),

--- a/setting/repository_info.go
+++ b/setting/repository_info.go
@@ -17,15 +17,6 @@ func (r *RepositoryInfo) IsReviewer(name string) bool {
 	return r.reviewers.Has(name)
 }
 
-func (r *RepositoryInfo) HasReviewer(list []string) bool {
-	for _, user := range list {
-		if r.IsReviewer(user) {
-			return true
-		}
-	}
-	return false
-}
-
 type ReviewerSet struct {
 	set map[string]*interface{}
 }

--- a/setting/repository_info.go
+++ b/setting/repository_info.go
@@ -17,6 +17,15 @@ func (r *RepositoryInfo) IsReviewer(name string) bool {
 	return r.reviewers.Has(name)
 }
 
+func (r *RepositoryInfo) HasReviewer(list []string) bool {
+	for _, user := range list {
+		if r.IsReviewer(user) {
+			return true
+		}
+	}
+	return false
+}
+
 type ReviewerSet struct {
 	set map[string]*interface{}
 }


### PR DESCRIPTION
- Fix https://github.com/karen-irc/popuko/issues/106
- By this change, we allow non-reviewer name to `r=<reviewer>`. But an only reviewer can ignite this command. It's not changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/popuko/207)
<!-- Reviewable:end -->
