### PR TITLE
Use github.com/golang/dep in the minefield

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ popuko
 
 # config file
 config.toml
+
+# https://github.com/golang/dep
+lock.json

--- a/Gomfile
+++ b/Gomfile
@@ -1,3 +1,0 @@
-gom 'github.com/BurntSushi/toml'
-gom 'github.com/google/go-github'
-gom 'golang.org/x/oauth2'

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ clean: ## Remove the exec binary.
 
 bootstrap:
 	rm -rf vendor/
-	go get -u github.com/mattn/gom
-	gom install
+	go get -u github.com/golang/dep
+	dep ensure -update
 
 build: $(DIST_NAME) ## Build the exec binary for youe machine.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,13 @@
+{
+    "dependencies": {
+        "github.com/BurntSushi/toml": {
+            "branch": "master"
+        },
+        "github.com/google/go-github": {
+            "branch": "master"
+        },
+        "golang.org/x/net": {
+            "branch": "master"
+        }
+    }
+}


### PR DESCRIPTION
- We know `dep` is pretty unstable. But we'd like to dogfooding it.
- We use the latest of each dependencies. So we don't include
  lock.json.
- All dependencies are specified in manifest.json. no problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/popuko/218)
<!-- Reviewable:end -->
