### PR TITLE
Fix the install process of dep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ clean: ## Remove the exec binary.
 
 bootstrap:
 	rm -rf vendor/
-	go get -u github.com/golang/dep
+	go get -u github.com/golang/dep/...
 	dep ensure -update
 
 build: $(DIST_NAME) ## Build the exec binary for youe machine.

--- a/tools/whitespace.txt
+++ b/tools/whitespace.txt
@@ -4,3 +4,4 @@ This is inspired by https://chromium.googlesource.com/v8/v8/+/master/tools/white
 demo
 demo
 test
+travis


### PR DESCRIPTION
Our build has broken at https://github.com/karen-irc/popuko/pull/223#issuecomment-276282574

I've met same circumstance at my local machine without `dep` command.

Our bootstraping process may have a trouble, so I fix it like official [Usage](https://github.com/golang/dep#usage).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karen-irc/popuko/224)
<!-- Reviewable:end -->
